### PR TITLE
Fixed admin event CRUD APIs

### DIFF
--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -114,6 +114,7 @@ export const eventCreate = [
     .withMessage('End time must be a valid date.')
     .toDate(),
   body('location').trim().isLength({ min: 1 }).withMessage('Location must be specified.'),
+  body('major_event').isBoolean().withMessage('Major event must be a boolean.'),
   body('description').optional().trim(),
   body('calendar_link')
     .trim()
@@ -124,7 +125,6 @@ export const eventCreate = [
   body('instagram_link')
     .trim()
     .custom((url) => {
-      console.log(url);
       if (url === '' || validator.isURL(url, { require_protocol: true })) {
         return true;
       }
@@ -229,6 +229,7 @@ export const eventUpdate = [
     .toDate()
     .withMessage('End time must be a valid date.'),
   body('location').optional().trim(),
+  body('major_event').optional().isBoolean().withMessage('Major event must be a boolean.'),
   body('description').optional().trim(),
   body('calendar_link')
     .optional()

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -114,7 +114,6 @@ export const eventCreate = [
     .withMessage('End time must be a valid date.')
     .toDate(),
   body('location').trim().isLength({ min: 1 }).withMessage('Location must be specified.'),
-  body('major_event').isBoolean().withMessage('Event must be major or minor.'),
   body('description').optional().trim(),
   body('calendar_link')
     .trim()
@@ -230,10 +229,6 @@ export const eventUpdate = [
     .toDate()
     .withMessage('End time must be a valid date.'),
   body('location').optional().trim(),
-  body('major_event')
-    .optional()
-    .isBoolean()
-    .withMessage('Major event must be either true or false.'),
   body('description').optional().trim(),
   body('calendar_link')
     .optional()

--- a/backend/models/event.js
+++ b/backend/models/event.js
@@ -5,6 +5,7 @@ const eventSchema = new Schema({
   start_time: { type: Date, required: true },
   end_time: { type: Date, required: true },
   location: { type: String, required: true },
+  major_event: Boolean,
   description: String,
   calendar_link: { type: String, required: true },
   instagram_link: String,

--- a/backend/models/event.js
+++ b/backend/models/event.js
@@ -5,7 +5,6 @@ const eventSchema = new Schema({
   start_time: { type: Date, required: true },
   end_time: { type: Date, required: true },
   location: { type: String, required: true },
-  major_event: { type: Boolean, required: true },
   description: String,
   calendar_link: { type: String, required: true },
   instagram_link: String,

--- a/backend/models/event.js
+++ b/backend/models/event.js
@@ -5,7 +5,7 @@ const eventSchema = new Schema({
   start_time: { type: Date, required: true },
   end_time: { type: Date, required: true },
   location: { type: String, required: true },
-  major_event: Boolean,
+  major_event: { type: Boolean, required: true },
   description: String,
   calendar_link: { type: String, required: true },
   instagram_link: String,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@2toad/profanity": "^2.2.0",

--- a/frontend/src/components/Membership/EventsDashboard.tsx
+++ b/frontend/src/components/Membership/EventsDashboard.tsx
@@ -11,6 +11,10 @@ import {
   TableRow,
   Modal,
   TextField,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl,
 } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -24,6 +28,7 @@ interface Event {
   start_time: string;
   end_time: string;
   location: string;
+  major_event: boolean;
   description: string;
   calendar_link: string;
   instagram_link: string;
@@ -63,6 +68,7 @@ const EventRow = ({
       <TableCell>{new Date(event.start_time).toLocaleString()}</TableCell>
       <TableCell>{new Date(event.end_time).toLocaleString()}</TableCell>
       <TableCell>{event.location}</TableCell>
+      <TableCell>{event.major_event.toString()}</TableCell>
       <TableCell>{event.description}</TableCell>
       <TableCell>{event.calendar_link}</TableCell>
       <TableCell>{event.instagram_link}</TableCell>
@@ -135,6 +141,21 @@ const EventRow = ({
               required
               helperText="Please enter the location of the event"
             />
+            <FormControl sx={{ minWidth: 100 }}>
+              <InputLabel id="major-event-label">Major Event</InputLabel>
+              <Select
+                labelId="major-event-label"
+                id="major_event"
+                value={editedEvent.major_event}
+                onChange={(e) => setEditedEvent({ ...editedEvent, major_event: e.target.value === "true" })}
+                label="Major event"
+                required
+                sx={{ maxHeight: 35 }}
+              > 
+                <MenuItem value={"true"}>True</MenuItem>
+                <MenuItem value={"false"}>False</MenuItem>
+              </Select>
+            </FormControl>
             <TextField
               label="Calendar Link"
               id="calendar_link"
@@ -202,6 +223,7 @@ const DashBoard = () => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [location, setLocation] = useState('');
+  const [majorEvent, setMajorEvent] = useState(false);
   const [calendarLink, setCalendarLink] = useState<String>();
   const [instagramLink, setInstagramLink] = useState<String>();
   const [startTime, setStartTime] = useState<Dayjs | null>(null);
@@ -225,6 +247,7 @@ const DashBoard = () => {
       title,
       description,
       location,
+      major_event: majorEvent,
       calendar_link: calendarLink,
       instagram_link: instagramLink,
       start_time: startTime.toISOString(),
@@ -327,6 +350,21 @@ const DashBoard = () => {
               required
               helperText="Please enter the location of the event"
             />
+            <FormControl sx={{ minWidth: 100 }}>
+              <InputLabel id="major-event-label">Major Event</InputLabel>
+              <Select
+                labelId="major-event-label"
+                id="major_event"
+                value={majorEvent}
+                onChange={(e) => setMajorEvent(e.target.value === "true")}
+                label="Major event"
+                required
+                sx={{ maxHeight: 35 }}
+              > 
+                <MenuItem value={"true"}>True</MenuItem>
+                <MenuItem value={"false"}>False</MenuItem>
+              </Select>
+            </FormControl>
             <TextField
               label="Calendar Link"
               id="calendar_link"
@@ -366,6 +404,7 @@ const DashBoard = () => {
               <TableCell>Start Time</TableCell>
               <TableCell>End Time</TableCell>
               <TableCell>Location</TableCell>
+              <TableCell>Major Event</TableCell>
               <TableCell>Description</TableCell>
               <TableCell>Calendar Link</TableCell>
               <TableCell>Instagram Link</TableCell>


### PR DESCRIPTION
Fixed admin event CRUD APIs so that create, and update methods are properly working.

Previously, create and update methods required major_event field, but this field was not being passed and wasn't part of the create and update forms.

This fix does the following:

1) Add major_event dropdown to create and update forms
2) Pass major_event attribute in request body
3) Include major_event in event dashboard view