### PR TITLE
Upload/edit profile picture functionality

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -29,13 +29,14 @@ export const userCheck = [
 ];
 
 export const userCreate = asyncHandler(async (req, res) => {
-  const { name, email, major, expectedGraduateYear } = req.body;
+  const { name, email, major, expectedGraduateYear, profilePicture } = req.body;
   const parsedGraduationYear = parseInt(expectedGraduateYear);
   const newUser = new User({
     name,
     email,
     major,
     expectedGraduationYear: parsedGraduationYear,
+    profilePicture,
   });
 
   try {
@@ -79,7 +80,7 @@ export const userUpdate = [
     .isArray()
     .custom(isValidEventId)
     .withMessage('Contains invalid event ID.'),
-  body('profilePicture').optional().isURL().withMessage('Invalid URL.'),
+  body('profilePicture').optional(),
 
   asyncHandler(async (req, res) => {
     const error = validationResult(req);

--- a/frontend/src/components/Login/EditProfile.tsx
+++ b/frontend/src/components/Login/EditProfile.tsx
@@ -24,6 +24,7 @@ interface EditFormProps {
   email: string;
   major: string;
   expectedGraduationYear: number;
+  profilePicture: string,
 }
 
 // Set up profanity checker
@@ -40,17 +41,21 @@ const EditForm = () => {
   const availableGradYears = useContext(GradYearsContext);
   const [selectedMajor, setSelectedMajor] = useState<string | null>(null);
   const [selectedGradYear, setSelectedGradYear] = useState<string | null>(null);
+
   const [showError, setShowError] = useState(false);
   const [nameEmptyError, setNameEmptyError] = useState(false);
   const [nameLengthError, setNameLengthError] = useState(false);
   const [nameProfanityError, setNameProfanityError] = useState(false);
   const [majorEmptyError, setMajorEmptyError] = useState(false);
   const [gradYearEmptyError, setGradYearEmptyError] = useState(false);
+  const [profilePictureError, setProfilePictureError] = useState<string | null>(null);
+
   const [formData, setFormData] = useState<EditFormProps>({
     name: '',
     email: '',
     major: '',
     expectedGraduationYear: 0,
+    profilePicture: '',
   });
 
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -69,6 +74,31 @@ const EditForm = () => {
     setFormData({ ...formData, expectedGraduationYear: numValue });
   };
 
+  const onProfilePictureChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        setProfilePictureError('Please select a valid image file.');
+        return;
+      }
+
+      const maxSize = 8 * 1024 * 1024; // 8 MB
+      if (file.size > maxSize) {
+        setProfilePictureError('File size exceeds the limit of 8 MB.');
+        return; 
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64String = reader.result as string;
+        setFormData({ ...formData, profilePicture: base64String });
+        setProfilePictureError(null);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
   useEffect(() => {
     const fetchUserData = async () => {
       try {
@@ -83,6 +113,7 @@ const EditForm = () => {
               email: response.data.email,
               major: response.data.major,
               expectedGraduationYear: response.data.expectedGraduationYear,
+              profilePicture: response.data.profilePicture,
             });
             setSelectedMajor(response.data.major);
             setSelectedGradYear(String(response.data.expectedGraduationYear));
@@ -109,6 +140,7 @@ const EditForm = () => {
     setNameProfanityError(false);
     setMajorEmptyError(false);
     setGradYearEmptyError(false);
+    setProfilePictureError(null);
 
     let hasErrors = false;
 
@@ -278,6 +310,26 @@ const EditForm = () => {
                   )}
                 </>
               )}
+            </FormControl>
+            
+            <FormControl
+              fullWidth
+              variant="standard"
+              sx={styles.inputField}
+            >
+              <InputLabel
+                htmlFor="profile-picture"
+                shrink
+              >
+                Change your Profile Picture (Optional)
+              </InputLabel>
+              <Input
+                id="profile-picture"
+                name="profilePicture"
+                type="file"
+                onChange={onProfilePictureChange}
+              />
+              {profilePictureError && <p style={{ color: 'red' }}>{profilePictureError}</p>}
             </FormControl>
 
             <Box sx={{ textAlign: 'center' }}>

--- a/frontend/src/components/Login/SignupForm.tsx
+++ b/frontend/src/components/Login/SignupForm.tsx
@@ -36,6 +36,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ name, email }) => {
   const availableGradYears = useContext(GradYearsContext);
   const [selectedMajor, setSelectedMajor] = useState<string | null>(null);
   const [selectedGradYear, setSelectedGradYear] = useState<string | null>(null);
+  const [profilePicture, setProfilePicture] = useState<string | null>(null);
 
   const [showError, setShowError] = useState(false);
   const [nameEmptyError, setNameEmptyError] = useState(false);
@@ -43,12 +44,14 @@ const SignupForm: React.FC<SignupFormProps> = ({ name, email }) => {
   const [nameProfanityError, setNameProfanityError] = useState(false);
   const [majorEmptyError, setMajorEmptyError] = useState(false);
   const [gradYearEmptyError, setGradYearEmptyError] = useState(false);
+  const [profilePictureError, setProfilePictureError] = useState<String | null>(null);
 
   const [formData, setFormData] = useState({
     name: name,
     email: email,
     major: '',
     expectedGraduateYear: 0,
+    profilePicture: profilePicture,
   });
 
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -65,6 +68,32 @@ const SignupForm: React.FC<SignupFormProps> = ({ name, email }) => {
     const numValue = Number(value);
     setSelectedGradYear(value);
     setFormData({ ...formData, expectedGraduateYear: numValue });
+  };
+
+  const onProfilePictureChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (file) {
+      if (!file.type.startsWith('image/')) {
+        setProfilePictureError('Please select a valid image file.');
+        return;
+      }
+
+      const maxSize = 8 * 1024 * 1024; // 8 MB
+      if (file.size > maxSize) {
+        setProfilePictureError('File size exceeds the limit of 8 MB.');
+        return; 
+      }
+
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64String = reader.result as string;
+        setProfilePicture(base64String);
+        setFormData({ ...formData, profilePicture: base64String });
+        setProfilePictureError(null);
+      };
+      reader.readAsDataURL(file);
+    }
   };
 
   const onFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -233,6 +262,26 @@ const SignupForm: React.FC<SignupFormProps> = ({ name, email }) => {
             )}
           </>
         )}
+      </FormControl>
+      
+      <FormControl
+        fullWidth
+        variant="standard"
+        sx={styles.inputField}
+      >
+        <InputLabel
+          htmlFor="profile-picture"
+          shrink
+        >
+          Upload a Profile Picture (Optional)
+        </InputLabel>
+        <Input
+          id="profile-picture"
+          name="profilePicture"
+          type="file"
+          onChange={onProfilePictureChange}
+        />
+        {profilePictureError && <p style={{ color: 'red' }}>{profilePictureError}</p>}
       </FormControl>
 
       <Box sx={{ textAlign: 'center' }}>

--- a/frontend/src/components/Login/SignupForm.tsx
+++ b/frontend/src/components/Login/SignupForm.tsx
@@ -105,6 +105,7 @@ const SignupForm: React.FC<SignupFormProps> = ({ name, email }) => {
     setNameProfanityError(false);
     setMajorEmptyError(false);
     setGradYearEmptyError(false);
+    setProfilePictureError(null);
 
     let hasErrors = false;
 

--- a/frontend/src/components/Login/styles.ts
+++ b/frontend/src/components/Login/styles.ts
@@ -23,7 +23,7 @@ export const loginStyles = () => ({
 
   editForm: {
     width: 350,
-    height: 400,
+    height: 450,
     padding: '20px',
     marginY: '150px',
     marginX: 'auto',

--- a/frontend/src/components/Login/styles.ts
+++ b/frontend/src/components/Login/styles.ts
@@ -14,7 +14,7 @@ export const loginStyles = () => ({
 
   signupForm: {
     width: 350,
-    height: 400,
+    height: 450,
     padding: '20px',
     marginY: '150px',
     borderRadius: '10px',

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -57,11 +57,13 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
             checkUserAPI({ email: userInfo.data.email }).then((data) => {
               if (data && data.exists === true) {
                 console.log('Check -- Valid Token & User Registered');
-                updateUserAPI(userInfo.data.email, {
-                  profilePicture: userInfo.data.picture.replaceAll('s96-c', 's384-c'),
-                }).catch((error) => {
-                  console.error(error);
-                });
+                if (!data.user.profilePicture) {
+                  updateUserAPI(userInfo.data.email, {
+                    profilePicture: userInfo.data.picture.replaceAll('s96-c', 's384-c'),
+                  }).catch((error) => {
+                    console.error(error);
+                  });
+                }
                 setIsNewUser(false);
                 setIsLoggedIn(true);
                 setUser(userInfo.data);


### PR DESCRIPTION
Added profile picture upload to user signup and edit forms.
    - Validates uploaded file (must be image and under 8 MB)
    - Converts image file to string (Base64)
    - Uploads to or edits database accordingly

If no profile picture is provided when a new user signs up, then the default Google profile picture is used.

See pictures:

1) New user signup form

<img width="945" alt="Screenshot 2024-02-08 164732" src="https://github.com/Will-Hsu/cses_webdev/assets/121465832/def79c76-6568-4abf-9967-f78c8db851ba">

2) New user signed in

<img width="946" alt="Screenshot 2024-02-08 164829" src="https://github.com/Will-Hsu/cses_webdev/assets/121465832/46ab80f4-b08e-4261-ab4e-186c2d932904">

3) Edit profile form

<img width="947" alt="Screenshot 2024-02-08 165055" src="https://github.com/Will-Hsu/cses_webdev/assets/121465832/fc17c22e-cf36-4a58-997d-17833ab38727">

4) Profile picture edited, changes saved

<img width="947" alt="Screenshot 2024-02-08 165108" src="https://github.com/Will-Hsu/cses_webdev/assets/121465832/07caae21-ce72-4490-9c63-b821729fee3b">
