### PR TITLE
add a "no client id found" check in case env file is not set up

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,6 +8,11 @@ import { AuthProvider } from './context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 const clientId = process.env.REACT_APP_GOOGLE_CLIENT_ID!;
+
+if(!clientId){
+  throw new Error("Client ID not found. Did you set up the enviornment files?");
+}
+
 root.render(
   <React.StrictMode>
     <GoogleOAuthProvider clientId={clientId}>


### PR DESCRIPTION
Just added a more specific error in case the env is not set up. Can change the wording if needed.

<img width="1183" alt="image" src="https://github.com/Will-Hsu/cses_webdev/assets/34536619/710170c5-cea8-4999-945c-b2a6a7879bd8">
