### PR TITLE
Home/About Page UI Fix (Mobile L)

### DIFF
--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -154,7 +154,7 @@ const About = () => {
           {isSmallScreen && (
             <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
               <Grid item sm={5} lg={3}>
-                <img src={lightBulb} alt="img" />
+                <img src={lightBulb} alt="img" style={{ width: '98%', height: '95%'}} />
               </Grid>
               <Grid item sm={6} lg={5}>
                 <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'center', xs: 'center' } }}>

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -243,11 +243,13 @@ const Home = () => {
                 ))}
               </div>
             )}
-            <Button
-              size="large"
-              text="See All Events ->"
-              onClick={() => navigate('/events')}
-            ></Button>
+            <div style={{ marginLeft: isMobile ? '-2%' : '-0.3%' }}> 
+              <Button
+                size="large"
+                text="See All Events ->"
+                onClick={() => navigate('/events')} 
+              ></Button>
+            </div>
           </div>
         </Container>
       </Box>


### PR DESCRIPTION
For Mobile L mode:
1. Adjusted the size of the light bulb image on the About page.
2. Adjusted the left margin of the "See All Events" button on the Home page to align with the section title "Upcoming Events".
<img width="485" alt="Screen Shot 2024-03-13 at 12 57 32 PM" src="https://github.com/Will-Hsu/cses_webdev/assets/114626933/fddfad66-d0fa-4445-ba38-f1824777a36d">
<img width="455" alt="Screen Shot 2024-03-13 at 1 08 46 PM" src="https://github.com/Will-Hsu/cses_webdev/assets/114626933/882e5134-a855-4b1d-a527-82d961406b6e">
