### PR TITLE
add auto labeling for PRs based on branch name

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,4 @@
+front-end: ['*/FE-*', '*/fe-*']
+back-end: ['*/BE-*', '*/be-*']
+bug: bug/*
+feature: feature/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,21 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read # for TimonVS/pr-labeler-action to read config file
+      pull-requests: write # for TimonVS/pr-labeler-action to add labels in PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+
+          


### PR DESCRIPTION
Potentially can add this auto labeler action which can label PRs based on the branch name. Since we already have the convention we enforce should just work. :)

Marketplace action page(it is free): https://github.com/marketplace/actions/pr-labeler