### PR TITLE
Change about page images to use ImageWithBoxShadow component

### DIFF
--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -30,36 +30,9 @@ const About = () => {
           <Box sx={{ backgroundColor: 'rgba(0,0,0,0.5)', maxWidth: '90%', margin: '0 auto' }}>
             <Grid
               container
-              sx={{ marginTop: '7%', paddingTop: '3%', display: 'flex', justifyContent: 'center' }}
-            >
-              <Grid
-                item
-                sm={6}
-                md={4}
-                lg={3}
-                sx={{
-                  paddingRight: {
-                    xs: '0%',
-                    sm: '5%',
-                  },
-                  textAlign: 'right',
-                  marginBottom: '5%',
-                  marginRight: '2%',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  marginTop: '1%',
-                }}
-              >
-                <img
+                <ImageWithBoxShadow 
                   src={about1}
                   alt="img"
-                  style={{
-                    maxWidth: '110%',
-                    height: 'auto',
-                    borderRadius: '10px',
-                    boxShadow: '10px 10px white',
-                  }}
                 />
               </Grid>
               <Grid item sm={6} md={5} lg={6}>
@@ -231,93 +204,10 @@ const About = () => {
               </Box>
             </Grid>
           </Grid> */}
-          {!isSmallScreen && (
-            <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
-              <Grid item sm={5} lg={5}>
-                <Box sx={{ color: 'white', textAlign: { md: 'left', sm: 'left', xs: 'center' } }}>
-                  <h1>How do I join?</h1>
-                </Box>
-                <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'left', xs: 'center' } }}>
-                  <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                    To become a general member, simply sign up with your UCSD email!
-                  </p>
-                  <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                    Do you want to be a part of the internal team? Become a member and follow us on
-                    our socials to be notified of when board applications open on a rolling basis.
-                  </p>
-                  <Box
-                    sx={{
-                      marginLeft: '-2%',
-                      display: 'flex',
-                      justifyContent: { xs: 'center', sm: 'left' },
-                    }}
-                  >
-                    <Button
-                      size="large"
-                      text="Become a Member ->"
-                      onClick={() => navigate('/membership')}
-                    />
-                  </Box>
-                </Box>
-              </Grid>
-              <Grid
-                item
-                sm={4}
-                lg={3}
-                sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}
-              >
-                <img
-                  src={about3}
-                  alt="img"
-                  style={{
-                    maxWidth: '100%',
-                    height: 'auto',
-                    borderRadius: '10px',
-                    boxShadow: '10px 10px white',
-                  }}
-                />
-              </Grid>
-            </Grid>
-          )}
-
-          {isSmallScreen && (
-            <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
-              <Grid item sm={5} lg={3}>
-                <img
-                  src={about3}
-                  alt="img"
-                  style={{
-                    maxWidth: '100%',
-                    height: 'auto',
-                    borderRadius: '10px',
-                    boxShadow: '10px 10px white',
-                  }}
-                />
-              </Grid>
-              <Grid item sm={6} lg={5}>
-                <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'center', xs: 'center' } }}>
-                  <h1>How do I join?</h1>
-                </Box>
-                <p style={{ color: 'white', textAlign: 'center' }}>
-                  Check out amazing events we have planned as well as the opportunities we have for
-                  members.
-                </p>
-                <Box
-                  sx={{
-                    marginLeft: '-2%',
-                    display: 'flex',
-                    justifyContent: { xs: 'center', sm: 'left', lg: 'left' },
-                  }}
-                >
-                  <Button
-                    size="large"
-                    text="Become a Member ->"
-                    onClick={() => navigate('/opportunities')}
-                  />
-                </Box>
-              </Grid>
-            </Grid>
-          )}
+              <ImageWithBoxShadow 
+                src={about3}
+                alt="img"
+              />
           <Communities />
           <MeetTheTeam />
         </Container>

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -30,12 +30,17 @@ const About = () => {
           <Box sx={{ backgroundColor: 'rgba(0,0,0,0.5)', maxWidth: '90%', margin: '0 auto' }}>
             <Grid
               container
+              pt={4}
+              pb={2}
+              justifyContent='center'
+            >
+              <Grid item sm={6} pb={6}>
                 <ImageWithBoxShadow 
                   src={about1}
                   alt="img"
                 />
               </Grid>
-              <Grid item sm={6} md={5} lg={6}>
+              <Grid item sm={6}>
                 <Box
                   sx={{
                     color: 'white',

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -107,91 +107,34 @@ const About = () => {
               </Box>
             </Grid>
           </Grid>
-            <Grid 
-            container 
-            justifyContent='center'
-            columnSpacing={12}
-            mt={12} 
-            spacing={4}
-            direction={isSmallScreen ? 'column-reverse' : 'row'}
-            >
-              <Grid item sm={5}>
-                <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'center', xs: 'center' } }}>
-                  <h1>Our Future</h1>
-                </Box>
-                <p
-                  style={{
-                    color: 'white',
-                    fontSize: 'clamp(15px, 3vw, 20px)',
-                    textAlign: isSmallScreen? 'center' : 'left',
-                  }}
-                >
-                  Our mission statement is to help our members get professional opportunities while
-                  fostering a network of individuals. We do this through quarterly career fairs,
-                  programs for career development, and project opportunities to gain experience.
-                </p>
-              </Grid>
-              <Grid item sm={3} maxHeight={"100%"}>
-                <img src={lightBulb} alt="img" />
-              </Grid>
-            </Grid>
-
-          {/* <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
-            <Grid
-              item
-              sm={4}
-              lg={3}
-              sx={{ display: 'flex', alignItems: 'center', marginRight: '3%' }}
-            >
-              <img
-                src={about2}
-                alt="img"
+          <Grid 
+          container 
+          justifyContent='center'
+          columnSpacing={12}
+          mt={12} 
+          spacing={4}
+          direction={isSmallScreen ? 'column-reverse' : 'row'}
+          >
+            <Grid item sm={5}>
+              <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'center', xs: 'center' } }}>
+                <h1>Our Future</h1>
+              </Box>
+              <p
                 style={{
-                  maxWidth: '100%',
-                  height: 'auto',
-                  borderRadius: '10px',
-                  boxShadow: '12px 12px white',
-                }}
-              />
-            </Grid>
-            <Grid item sm={5} lg={5}>
-              <Box
-                sx={{
                   color: 'white',
-                  textAlign: { md: 'left', sm: 'left', xs: 'center' },
-                  fontSize: { xs: '0.9em', sm: '1em', lg: '1em' },
+                  fontSize: 'clamp(15px, 3vw, 20px)',
+                  textAlign: isSmallScreen? 'center' : 'left',
                 }}
               >
-                <h1>What's in store for me?</h1>
-              </Box>
-              <Box
-                sx={{
-                  display: 'flex',
-                  textAlign: { xs: 'center', sm: 'left' }, // Center on small screens, start from top on larger screens
-                }}
-              >
-                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                  Check out amazing events we have planned as well as the opportunities we have for
-                  members.
-                </p>
-              </Box>
-              <Box
-                sx={{
-                  marginLeft: '-2%',
-                  display: 'flex',
-                  justifyContent: { xs: 'center', sm: 'left', lg: 'left' },
-                }}
-              >
-                <div style={{ fontFamily: 'Chakra Petch' }}>
-                  <Button
-                    size="large"
-                    text="See Opportunities ->"
-                    onClick={() => navigate('/opportunities')}
-                  />
-                </div>
-              </Box>
+                Our mission statement is to help our members get professional opportunities while
+                fostering a network of individuals. We do this through quarterly career fairs,
+                programs for career development, and project opportunities to gain experience.
+              </p>
             </Grid>
-          </Grid> */}
+            <Grid item sm={3} maxHeight={"100%"}>
+              <img src={lightBulb} alt="img" />
+            </Grid>
+          </Grid>
           <Grid 
           container 
           justifyContent='center' 

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -34,14 +34,15 @@ const About = () => {
               pt={4}
               pb={2}
               justifyContent='center'
+              alignItems='center'
             >
-              <Grid item sm={6} pb={6}>
+              <Grid item sm={5} pl={{lg:'8%'}} pr={{lg:'2%'}}>
                 <ImageWithBoxShadow 
                   src={about1}
                   alt="img"
                 />
               </Grid>
-              <Grid item sm={6}>
+              <Grid item sm={7} pr={{lg: '8%'}}>
                 <Box
                   sx={{
                     color: 'white',

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -107,35 +107,15 @@ const About = () => {
               </Box>
             </Grid>
           </Grid>
-          {!isSmallScreen && (
-            <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
-              <Grid item sm={5.5} lg={5.5}>
-                <Box sx={{ color: 'white', marginBottom: 'auto' }}>
-                  <h1>Our Future</h1>
-                </Box>
-                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                  Our mission statement is to help our members get professional opportunities while
-                  fostering a network of individuals. We do this through quarterly career fairs,
-                  programs for career development, and project opportunities to gain experience.
-                </p>
-              </Grid>
-
-              <Grid
-                item
-                sm={3.5}
-                lg={2.5}
-                sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end' }}
-              >
-                <img src={lightBulb} alt="img" style={{ marginRight: '10%', height: '75%' }} />
-              </Grid>
-            </Grid>
-          )}
-          {isSmallScreen && (
-            <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
-              <Grid item sm={5} lg={3}>
-                <img src={lightBulb} alt="img" style={{ width: '98%', height: '95%'}} />
-              </Grid>
-              <Grid item sm={6} lg={5}>
+            <Grid 
+            container 
+            justifyContent='center'
+            columnSpacing={12}
+            mt={12} 
+            spacing={4}
+            direction={isSmallScreen ? 'column-reverse' : 'row'}
+            >
+              <Grid item sm={5}>
                 <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'center', xs: 'center' } }}>
                   <h1>Our Future</h1>
                 </Box>
@@ -143,7 +123,7 @@ const About = () => {
                   style={{
                     color: 'white',
                     fontSize: 'clamp(15px, 3vw, 20px)',
-                    textAlign: 'center',
+                    textAlign: isSmallScreen? 'center' : 'left',
                   }}
                 >
                   Our mission statement is to help our members get professional opportunities while
@@ -151,8 +131,10 @@ const About = () => {
                   programs for career development, and project opportunities to gain experience.
                 </p>
               </Grid>
+              <Grid item sm={3} maxHeight={"100%"}>
+                <img src={lightBulb} alt="img" />
+              </Grid>
             </Grid>
-          )}
 
           {/* <Grid container sx={{ marginTop: '10%', display: 'flex', justifyContent: 'center' }}>
             <Grid

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -12,6 +12,7 @@ import Communities from './OurCommunities';
 import about1 from '../../images/aboutpage/about_1.jpg';
 import about2 from '../../images/aboutpage/about_2.jpg';
 import about3 from '../../images/aboutpage/about_3.jpg';
+import { ImageWithBoxShadow } from '../Opportunities/Opportunities';
 
 const About = () => {
   const navigate = useNavigate();

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -204,10 +204,45 @@ const About = () => {
               </Box>
             </Grid>
           </Grid> */}
+          <Grid 
+          container 
+          justifyContent='center' 
+          mt={12} mb={12} 
+          direction={isSmallScreen ? 'column-reverse' : 'row'} >
+            <Grid item sm={5}>
+              <Box sx={{ color: 'white', textAlign: { md: 'left', sm: 'left', xs: 'center' } }}>
+                <h1>How do I join?</h1>
+              </Box>
+              <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'left', xs: 'center' } }}>
+                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
+                  To become a general member, simply sign up with your UCSD email!
+                </p>
+                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
+                  Do you want to be a part of the internal team? Become a member and follow us on
+                  our socials to be notified of when board applications open on a rolling basis.
+                </p>
+                <Box
+                  sx={{
+                    marginLeft: '-2%',
+                    display: 'flex',
+                    justifyContent: { xs: 'center', sm: 'left' },
+                  }}
+                >
+                  <Button
+                    size="large"
+                    text="Become a Member ->"
+                    onClick={() => navigate('/membership')}
+                  />
+                </Box>
+              </Box>
+            </Grid>
+            <Grid item sm={5}>
               <ImageWithBoxShadow 
                 src={about3}
                 alt="img"
               />
+            </Grid>
+          </Grid>
           <Communities />
           <MeetTheTeam />
         </Container>

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -135,45 +135,51 @@ const About = () => {
               <img src={lightBulb} alt="img" />
             </Grid>
           </Grid>
-          <Grid 
-          container 
-          justifyContent='center' 
-          mt={12} mb={12} 
-          direction={isSmallScreen ? 'column-reverse' : 'row'} >
-            <Grid item sm={5}>
-              <Box sx={{ color: 'white', textAlign: { md: 'left', sm: 'left', xs: 'center' } }}>
-                <h1>How do I join?</h1>
-              </Box>
-              <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'left', xs: 'center' } }}>
-                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                  To become a general member, simply sign up with your UCSD email!
-                </p>
-                <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
-                  Do you want to be a part of the internal team? Become a member and follow us on
-                  our socials to be notified of when board applications open on a rolling basis.
-                </p>
-                <Box
-                  sx={{
-                    marginLeft: '-2%',
-                    display: 'flex',
-                    justifyContent: { xs: 'center', sm: 'left' },
-                  }}
-                >
-                  <Button
-                    size="large"
-                    text="Become a Member ->"
-                    onClick={() => navigate('/membership')}
-                  />
+
+        <Container maxWidth="xl" sx={styles.body}>
+          <Box sx={{maxWidth: '90%', margin: '0 auto' }}>
+            <Grid 
+              container 
+              justifyContent='center' 
+              mt={12} mb={12} 
+              direction={isSmallScreen ? 'column-reverse' : 'row'}
+            >
+              <Grid item sm={7} pl={{lg: '8%'}}>
+                <Box sx={{ color: 'white', textAlign: { md: 'left', sm: 'left', xs: 'center' } }}>
+                  <h1>How do I join?</h1>
                 </Box>
-              </Box>
+                <Box sx={{ color: 'white', textAlign: { lg: 'left', sm: 'left', xs: 'center' } }}>
+                  <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
+                    To become a general member, simply sign up with your UCSD email!
+                  </p>
+                  <p style={{ color: 'white', fontSize: 'clamp(15px, 3vw, 20px)' }}>
+                    Do you want to be a part of the internal team? Become a member and follow us on
+                    our socials to be notified of when board applications open on a rolling basis.
+                  </p>
+                  <Box
+                    sx={{
+                      marginLeft: '-2%',
+                      display: 'flex',
+                      justifyContent: { xs: 'center', sm: 'left' },
+                    }}
+                  >
+                    <Button
+                      size="large"
+                      text="Become a Member ->"
+                      onClick={() => navigate('/membership')}
+                    />
+                  </Box>
+                </Box>
+              </Grid>
+              <Grid item sm={5} pl={{lg:'2%'}} pr={{lg:'8%'}}>
+                <ImageWithBoxShadow 
+                  src={about3}
+                  alt="img"
+                />
+              </Grid>
             </Grid>
-            <Grid item sm={5}>
-              <ImageWithBoxShadow 
-                src={about3}
-                alt="img"
-              />
-            </Grid>
-          </Grid>
+          </Box>
+        </Container>
           <Communities />
           <MeetTheTeam />
         </Container>

--- a/frontend/src/components/About/About.tsx
+++ b/frontend/src/components/About/About.tsx
@@ -53,8 +53,7 @@ const About = () => {
                     style={{
                       fontFamily: 'Chakra Petch',
                       fontSize: 'clamp(32px, 8vw, 65px)',
-                      fontWeight: '700',
-                      marginTop: '0',
+                      fontWeight: '700'
                     }}
                   >
                     WHAT IS CSES?

--- a/frontend/src/components/Opportunities/Opportunities.tsx
+++ b/frontend/src/components/Opportunities/Opportunities.tsx
@@ -14,13 +14,13 @@ import { useNavigate } from 'react-router-dom';
 interface ImageWithBoxShadowProps {
   src: string;
   alt: string;
-  boxColor: string;
+  boxColor?: string;
   borderColor?: string
   /* Optional clickable link */
   href?: string
 }
 
-export const ImageWithBoxShadow = ({ src, alt, boxColor, borderColor, href}: ImageWithBoxShadowProps) => {
+export const ImageWithBoxShadow = ({ src, alt, boxColor='white', borderColor, href}: ImageWithBoxShadowProps) => {
   const theme = useTheme();
   const styles = opportunitiesStyles(theme);
   return (

--- a/frontend/src/components/Opportunities/Opportunities.tsx
+++ b/frontend/src/components/Opportunities/Opportunities.tsx
@@ -20,7 +20,7 @@ interface ImageWithBoxShadowProps {
   href?: string
 }
 
-const ImageWithBoxShadow = ({ src, alt, boxColor, borderColor, href}: ImageWithBoxShadowProps) => {
+export const ImageWithBoxShadow = ({ src, alt, boxColor, borderColor, href}: ImageWithBoxShadowProps) => {
   const theme = useTheme();
   const styles = opportunitiesStyles(theme);
   return (

--- a/frontend/src/components/Opportunities/Opportunities.tsx
+++ b/frontend/src/components/Opportunities/Opportunities.tsx
@@ -64,7 +64,6 @@ const Opportunities = () => {
             <ImageWithBoxShadow 
               src={members}
               alt='members'
-              boxColor='white'
             />
           </Grid>
           <Grid item xs={12} sm={6}>
@@ -110,7 +109,6 @@ const Opportunities = () => {
           <ImageWithBoxShadow 
               src={sponsors}
               alt="sponsors"
-              boxColor='white'
             />
           </Grid>
           <Grid item xs={12} sm={6}>

--- a/frontend/src/components/Opportunities/Opportunities.tsx
+++ b/frontend/src/components/Opportunities/Opportunities.tsx
@@ -28,7 +28,12 @@ export const ImageWithBoxShadow = ({ src, alt, boxColor, borderColor, href}: Ima
       <img
         src={src}
         alt={alt}
-        style={{ width: '85%', height: 'auto', boxShadow: `12px 12px ${boxColor}`, border: borderColor?`2px solid ${borderColor}`:``}}
+        style={{ 
+          width: '85%', 
+          height: 'auto', 
+          boxShadow: `12px 12px ${boxColor}`, 
+          border: borderColor?`2px solid ${borderColor}`:``
+        }}
       />
     </a>
   );


### PR DESCRIPTION
Changed the image to use the ImageWithBoxShadow component. Did not make the corners rounded as before for consistency but can add it if you think it is more important to stick to original design.
<img width="1135" alt="image" src="https://github.com/Will-Hsu/cses_webdev/assets/34536619/8c43aead-b4e3-424c-b40e-cdf1ac2991b4">
<img width="1138" alt="image" src="https://github.com/Will-Hsu/cses_webdev/assets/34536619/de5ddc07-915c-4b43-8f87-58835aa6df22">

Also changed how the 2nd image is made to align with the text through conditional direction attribute. In the past I we just rendered a different copy of the component. Still achieves same result.
<img width="406" alt="image" src="https://github.com/Will-Hsu/cses_webdev/assets/34536619/ba68be6e-38a4-4de3-b786-a6e3d8b57d3c">

Also changed how the lightbulb is rendered the same way and rewrote its implementation to use the grid system as well.
<img width="1137" alt="image" src="https://github.com/Will-Hsu/cses_webdev/assets/34536619/22a9ef32-859f-4c93-a171-c00286d40bc0">

I think the other components could use the same rewrite but due to large number would be better as a separate PR.