### PR TITLE
Remove Cses Web Dev Community Tab

### DIFF
--- a/frontend/src/components/About/MeetTheTeam.tsx
+++ b/frontend/src/components/About/MeetTheTeam.tsx
@@ -86,19 +86,6 @@ const categories = [
     ],
   },
   {
-    id: 3,
-    name: 'CSES WebDev',
-    members: [
-      { name: 'Shruti Bhamidipati', title: 'President', photo: Shruti },
-      { name: 'Manan Patel', title: 'VP Finance', photo: Manan },
-      { name: 'Jheel Gandhi', title: 'VP Design', photo: Jheel },
-      { name: 'Sonia Fereidooni', title: 'VP Operations', photo: Sonia },
-      { name: 'Ryan Rickey', title: 'Software Team Lead', photo: Ryan },
-      { name: 'Jake Villaseno', title: 'UI/UX Designer', photo: Jake },
-      //{ name: 'Saleha Ahmedi', title: 'WebDev', photo: Saleha},
-    ],
-  },
-  {
     id: 4,
     name: 'CSES Open Source',
     members: [

--- a/frontend/src/components/About/OurCommunities.tsx
+++ b/frontend/src/components/About/OurCommunities.tsx
@@ -39,27 +39,6 @@ const Communities = () => {
               margin: verySmallScreen ? '10% 0% 0% 0%' : { xs: '10% 2% 2% 2%', sm: '5% 3%', md: '3% 2%' }
             }}>
             <img
-              src={innovate}
-              alt="Innovate"
-              style={{ ...styles.communityCardImg, backgroundColor: 'black'}}
-            />
-            <Box sx={{ height: 'auto', padding: verySmallScreen ? '2%' : '4%', alignSelf: 'center' }}>
-              <Box sx={{ ...styles.subheadingTop }} >
-                CSES Innovate
-              </Box>
-              <p style={{ color: 'black', fontSize: 'clamp(8px, 2vw, 16px)', marginTop: verySmallScreen ? '2px' :'6px'}}>
-                Learn about tech entrepreneurship! Form teams and build your own start-ups from ideation to pitch.
-              </p>
-            </Box>
-          </Grid>
-          <Grid item 
-            sx={{
-              ...styles.communityCard,
-              width: verySmallScreen ? '250px' : { xs: '350px', sm: '500px', md: '500px' },
-              height: verySmallScreen ? '84px' : { xs: '100px', sm: '160px', md: '160px' },
-              margin: verySmallScreen ? '10% 0% 0% 0%' : { xs: '10% 2% 2% 2%', sm: '5% 3%', md: '3% 2%' }
-            }}>
-            <img
               src={dev}
               alt="Dev"
               style={{ ...styles.communityCardImg, backgroundColor: 'black'}}
@@ -91,6 +70,27 @@ const Communities = () => {
               </Box>
               <p style={{ color: 'black', fontSize: 'clamp(8px, 2vw, 16px)', marginTop: verySmallScreen ? '2px' : '6px'}}>
                 No projects? No problem! Build your skills and collaborate with other students on real projects, no application required!
+              </p>
+            </Box>
+          </Grid>
+          <Grid item 
+            sx={{
+              ...styles.communityCard,
+              width: verySmallScreen ? '250px' : { xs: '350px', sm: '500px', md: '500px' },
+              height: verySmallScreen ? '84px' : { xs: '100px', sm: '160px', md: '160px' },
+              margin: verySmallScreen ? '10% 0% 0% 0%' : { xs: '10% 2% 2% 2%', sm: '5% 3%', md: '3% 2%' }
+            }}>
+            <img
+              src={innovate}
+              alt="Innovate"
+              style={{ ...styles.communityCardImg, backgroundColor: 'black'}}
+            />
+            <Box sx={{ height: 'auto', padding: verySmallScreen ? '2%' : '4%', alignSelf: 'center' }}>
+              <Box sx={{ ...styles.subheadingTop }} >
+                CSES Innovate
+              </Box>
+              <p style={{ color: 'black', fontSize: 'clamp(8px, 2vw, 16px)', marginTop: verySmallScreen ? '2px' :'6px'}}>
+                Learn about tech entrepreneurship! Form teams and build your own start-ups from ideation to pitch.
               </p>
             </Box>
           </Grid>

--- a/frontend/src/components/About/OurCommunities.tsx
+++ b/frontend/src/components/About/OurCommunities.tsx
@@ -94,27 +94,6 @@ const Communities = () => {
               </p>
             </Box>
           </Grid>
-          <Grid item 
-            sx={{
-              ...styles.communityCard,
-              width: verySmallScreen ? '250px' : { xs: '350px', sm: '500px', md: '500px' },
-              height: verySmallScreen ? '84px' : { xs: '100px', sm: '160px', md: '160px' },
-              margin: verySmallScreen ? '10% 0% 0% 0%' : { xs: '10% 2% 2% 2%', sm: '5% 3%', md: '3% 2%' }
-            }}>
-            <img
-              src={webdev}
-              alt="WebDev"
-              style={{ ...styles.communityCardImg}}
-            />
-            <Box sx={{ height: 'auto', padding: verySmallScreen ? '2%' : '4%', alignSelf: 'center' }}>
-              <Box sx={{ ...styles.subheadingTop }} >
-                CSES WebDev
-              </Box>
-              <p style={{ color: 'black', fontSize: 'clamp(8px, 2vw, 16px)', marginTop: verySmallScreen ? '2px' : '6px'}}>
-                Gain hands-on experience in web design and development for real clients, from UCSD clubs to non-profits!
-              </p>
-            </Box>
-          </Grid>
         </Grid>
       </Grid>
     </Container>


### PR DESCRIPTION
Removed Cses Web Dev Community Tab 

Reordered Communities Tabs to be in same order as CSES Image Tabs 
<img width="1134" alt="Screenshot 2024-05-27 at 1 52 03 AM" src="https://github.com/Will-Hsu/cses_webdev/assets/72182003/94b19d3d-3a77-4d0b-892d-456a1e0a7c4f">

<img width="975" alt="Screenshot 2024-05-27 at 1 52 13 AM" src="https://github.com/Will-Hsu/cses_webdev/assets/72182003/8ecccf21-686c-4ca3-a3ab-f7122cd5ab7a">
